### PR TITLE
fix: deploy docs to GitHub Pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,3 +86,11 @@ jobs:
           pip install --requirement requirements-docs.txt
       - name: Build docs
         run: make docs
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/build/html/
+          force_orphan: true


### PR DESCRIPTION
Closes #4, where project Sphinx documentation was not being deployed to GitHub Pages in line with its latest implementation.