### PR TITLE
fix: remove redundant doctests pipeline task

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,8 +63,6 @@ jobs:
           name: code-coverage-report
           path: docs/coverage
           retention-days: 5
-      - name: Run doctests
-        run: pytest --doctest-modules pysamplelib
 
   build-docs:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Removes redundant task to run package doctests, which are already integrated and executed as part of the full unit test suite alongside unit test modules.