### PR TITLE
fix: exclude type check blocks in coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ branch = true
 omit = ["*/tests/*", "*/venv/*"]
 
 [tool.coverage.report]
+exclude_lines = [
+    # TYPE_CHECKING blocks are never executed during pytest run
+    "if typing.TYPE_CHECKING:",
+]
 fail_under = 90.00
 show_missing = true
 


### PR DESCRIPTION
Exclude `typing.TYPE_CHECKING` blocks from test coverage metrics as they are never executed during test execution.