### PR TITLE
fix: bump pyprojectsort from 0.2.1 to 0.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,6 @@ repos:
         args: [--configfile=pyproject.toml, --severity-level=medium, .]
         additional_dependencies: ["bandit[toml]"]
   - repo: https://github.com/kieran-ryan/pyprojectsort
-    # pyprojectsort version.
-    rev: d9cf5e1e646e1e5260f7cf0168ecd0a05ce8ed11
+    rev: v0.3.0
     hooks:
       - id: pyprojectsort

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ blacken-docs==1.14.0
 mypy==0.971
 perflint==0.7.3
 pre-commit==3.3.3
-pyprojectsort==0.2.1
+pyprojectsort==0.3.0
 pyupgrade==3.7.0
 radon[toml]==6.0.1
 removestar==1.3.1


### PR DESCRIPTION
- Bump `pyprojectsort` from 0.2.1 to 0.3.0